### PR TITLE
Calculate frame weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .idea/
 build_dist.sh
 .pytest_cache/
+plumitas/dev_data

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ build/
 .idea/
 build_dist.sh
 .pytest_cache/
-plumitas/dev_data

--- a/plumitas/core.py
+++ b/plumitas/core.py
@@ -400,6 +400,19 @@ class PBMetaDProject(SamplingProject):
                 periodic = True
 
             n_bins = 5 * (grid_max - grid_min) / sigma
+            if ('grid_slicing' in self.bias_params.keys()
+                    and 'grid_bin' in self.bias_params.keys()):
+                bins = get_float(self.bias_params['grid_bin'])
+                slicing = get_float(self.bias_params['slicing'])
+                slice_bins = (grid_max - grid_min) / slicing
+                n_bins = max(bins, slice_bins)
+            elif ('grid_slicing' in self.bias_params.keys()
+                  and 'grid_bin' not in self.bias_params.keys()):
+                slicing = get_float(self.bias_params['slicing'])
+                n_bins = (grid_max - grid_min) / slicing
+            elif ('grid_bin' in self.bias_params.keys()
+                  and 'grid_slicing' not in self.bias_params.keys()):
+                n_bins = get_float(self.bias_params['grid_bin'])
 
             grid = np.linspace(grid_min, grid_max, num=n_bins)
             s_i = self.hills[CV][CV].values
@@ -464,3 +477,20 @@ class PBMetaDProject(SamplingProject):
 
         self.colvar['weight'] = weight / np.sum(weight)
         return
+
+############################################
+# Junk to test with
+############################################
+
+
+hills_files = 'data/belfast-6/Exercise_1/HILLS'
+colvar_files = 'data/belfast-6/Exercise_1/COLVAR'
+plumed_file = 'data/belfast-6/Exercise_1/plumed.dat'
+
+project = load_project(colvar_files, hills_files, method='metad',
+                       input_file=plumed_file, bias_type='metad',
+                       multi=False)
+
+project.reconstruct_bias_potential()
+project.weight_frames()
+

--- a/plumitas/core.py
+++ b/plumitas/core.py
@@ -345,7 +345,7 @@ class MetaDProject(SamplingProject):
                 bins = get_float(self.bias_params['grid_bin'])
                 slicing = get_float(self.bias_params['slicing'])
                 slice_bins = (grid_max - grid_min) / slicing
-                n_bins = min(bins, slice_bins)
+                n_bins = max(bins, slice_bins)
             elif ('grid_slicing' in self.bias_params.keys()
                   and 'grid_bin' not in self.bias_params.keys()):
                 slicing = get_float(self.bias_params['slicing'])
@@ -365,7 +365,7 @@ class MetaDProject(SamplingProject):
 
             self.static_bias[CV] = pd.Series(bias_potential,
                                              index=grid)
-            
+
 
 class PBMetaDProject(SamplingProject):
     def __init__(self, colvar, hills, input_file=None,

--- a/plumitas/core.py
+++ b/plumitas/core.py
@@ -3,11 +3,9 @@ import os
 import re
 from collections import namedtuple
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-import plumitas as plm
 
 GridParameters = namedtuple('GridParameters',
                             ['sigma', 'grid_min', 'grid_max'])
@@ -174,7 +172,8 @@ def sum_hills(grid_points, hill_centers, sigma, periodic=False):
 
     if periodic:
         # can probably do something smarter than this!
-        neg_dist = np.abs(dist_from_center) - (grid_points[-1] - grid_points[0])
+        neg_dist = (np.abs(dist_from_center)
+                    - (grid_points[-1] - grid_points[0]))
         neg_square = neg_dist * neg_dist
         square = np.minimum(square, neg_square)
 
@@ -280,16 +279,19 @@ class SamplingProject:
 
     def get_bias_params(self, input_file, bias_type):
         """
-        Method to grab bias parameters incase user forgot to supply plumed.dat
-        or input file wasn't automatically identified in the working directory.
+        Method to grab bias parameters incase user forgot to supply
+        plumed.dat or input file wasn't automatically identified in
+        the working directory.
 
         Parameters
         ----------
         input_file : string
-            Relative path to PLUMED input file. Most commonly called plumed.dat.
+            Relative path to PLUMED input file. Most commonly called
+            plumed.dat.
         bias_type : string
-            String associated with biasing method used for enhanced sampling.
-            Currently only "MetaD" and "PBMetaD" supported (case insensitive).
+            String associated with biasing method used for enhanced
+            sampling. Currently only "MetaD" and "PBMetaD" supported
+            (case insensitive).
 
         Returns
         -------
@@ -319,7 +321,6 @@ class MetaDProject(SamplingProject):
                                            bias_type=bias_type,
                                            multi=multi)
         self.method = 'MetaD'
-        self.temp = 300  # BS placeholder. forgive me, science for i have sinned.
 
     def reconstruct_bias_potential(self):
         if not self.biased_CVs:


### PR DESCRIPTION
Added reweighting methods for PBMetaD and MetaD. This PR should close #2. Torrie-Valleau can now be performed directly from HILLS and COLVAR files, without using `mdrun rerun` in GROMACS to get a quasi-static bias. I haven't really optimized these methods, but doing this in python is already way faster than using GROMACS (~1 min vs. a couple hours for a large PBMetaD with multiple walkers project).